### PR TITLE
Updating linux makefile to use sdl2 autoconfig for libs and cflags

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,7 +1,7 @@
 
-CFLAGS=-Wall -Wpedantic -std=c99
+CFLAGS=-Wall -Wpedantic -std=c99  $(shell sdl2-config --cflags)
 
-LDLIBS=-lSDL2
+LDLIBS=-lSDL2 $(shell sdl2-config --libs)
 
 EXE =   jc_reborn
 

--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,7 +1,7 @@
 
 CFLAGS=-Wall -Wpedantic -std=c99  $(shell sdl2-config --cflags)
 
-LDLIBS=-lSDL2 $(shell sdl2-config --libs)
+LDLIBS=$(shell sdl2-config --libs)
 
 EXE =   jc_reborn
 


### PR DESCRIPTION
Been working on some ports of your most excellent jc_reborn re-implementation.  Really love what you've done, please continue and thanks so much, your version really makes me happy! 

PR - Description -> 
Updating the linux makefile to use the sdl2-config autosettings for libs and cflags.

Functionality ->  
On some systems there are additional includes required to build a working executable, sdl2-config (bundled with sdl2-dev) figures this out dynamically. (no makefile changes necessary to compile on raspberry pi, ubuntu bionic 64, etc)


