### PR TITLE
Support for building with Emscripten

### DIFF
--- a/Makefile.linux
+++ b/Makefile.linux
@@ -1,9 +1,17 @@
-
 CFLAGS=-Wall -Wpedantic -std=c99
 
 LDLIBS=-lSDL2
 
-EXE =   jc_reborn
+BASE_EXE = jc_reborn
+
+ifdef EMSCRIPTEN
+EXE =   $(BASE_EXE).js
+ASSET_DIR=./assets@/
+CFLAGS+=-sUSE_SDL=2 -Os
+LDFLAGS+=--embed-file $(ASSET_DIR) -sASYNCIFY -sALLOW_MEMORY_GROWTH -sSTANDALONE_WASM=0 -sEXIT_RUNTIME
+else
+EXE =   $(BASE_EXE)
+endif
 
 OBJ =   jc_reborn.o \
         utils.o \
@@ -22,11 +30,13 @@ OBJ =   jc_reborn.o \
         events.o \
         config.o
 
-
 all: $(EXE)
 
 $(EXE): $(OBJ)
+ifdef EMSCRIPTEN
+	emcc $(OBJ) -o $(EXE) $(LDLIBS) $(LDFLAGS)
+endif
 
 clean:
-	rm -v $(OBJ) $(EXE) 2> /dev/null ; true
+	rm -v $(OBJ) $(BASE_EXE) $(BASE_EXE).js $(BASE_EXE).wasm 2> /dev/null ; true
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Johnny Reborn is an open source engine for the classic Johnny Castaway screen saver, developed by Dynamix for Windows 3.x and published by Sierra, back in 1992.
 
-It is written in C using the SDL2 library, and was successfully compiled and tested on Linux as well as Windows (MinGW), both 32 and 64 bits.
+It is written in C using the SDL2 library, and was successfully compiled and tested on Linux, on MacOSX, on Chrome and FireFox via Emscripten, as well as Windows (MinGW), both 32 and 64 bits.
 
 
 ## How to install

--- a/events.c
+++ b/events.c
@@ -76,7 +76,6 @@ static void eventsProcessEvents()
                         case SDLK_ESCAPE:
                             graphicsEnd();
 #ifdef __EMSCRIPTEN__
-                            emscripten_cancel_main_loop();
                             emscripten_force_exit(255);
 #else
                             exit(255);
@@ -89,7 +88,6 @@ static void eventsProcessEvents()
                     // terminates if any key is pressed
                     graphicsEnd();
 #ifdef __EMSCRIPTEN__
-                    emscripten_cancel_main_loop();
                     emscripten_force_exit(255);
 #else
                     exit(255);
@@ -104,7 +102,6 @@ static void eventsProcessEvents()
             case SDL_QUIT:
                 graphicsEnd();
 #ifdef __EMSCRIPTEN__
-                emscripten_cancel_main_loop();
                 emscripten_force_exit(255);
 #else
                 exit(255);

--- a/events.c
+++ b/events.c
@@ -25,6 +25,9 @@
 #include <stdio.h>
 
 #include <SDL2/SDL.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 #include "mytypes.h"
 #include "graphics.h"
 #include "events.h"
@@ -72,7 +75,12 @@ static void eventsProcessEvents()
 
                         case SDLK_ESCAPE:
                             graphicsEnd();
+#ifdef __EMSCRIPTEN__
+                            emscripten_cancel_main_loop();
+                            emscripten_force_exit(255);
+#else
                             exit(255);
+#endif
                             break;
                     }
                 }
@@ -80,7 +88,12 @@ static void eventsProcessEvents()
                     // Normal behaviour : no hot keys, the screen saver
                     // terminates if any key is pressed
                     graphicsEnd();
+#ifdef __EMSCRIPTEN__
+                    emscripten_cancel_main_loop();
+                    emscripten_force_exit(255);
+#else
                     exit(255);
+#endif
                 }
                 break;
 
@@ -90,7 +103,12 @@ static void eventsProcessEvents()
 
             case SDL_QUIT:
                 graphicsEnd();
+#ifdef __EMSCRIPTEN__
+                emscripten_cancel_main_loop();
+                emscripten_force_exit(255);
+#else
                 exit(255);
+#endif
                 break;
         }
     }
@@ -112,7 +130,11 @@ void eventsWaitTick(uint16 delay)
 
     while ((paused && !oneFrame)
             || (!maxSpeed && (SDL_GetTicks() - lastTicks < delay))) {
+#ifdef __EMSCRIPTEN__
+        emscripten_sleep(5);
+#else
         SDL_Delay(5);
+#endif
         eventsProcessEvents();
     }
 

--- a/graphics.c
+++ b/graphics.c
@@ -25,6 +25,9 @@
 #include <string.h>
 #include <time.h>
 #include <SDL2/SDL.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten/html5.h>
+#endif
 
 #include "mytypes.h"
 #include "utils.h"
@@ -122,6 +125,9 @@ void graphicsInit()
         SCREEN_HEIGHT,
         (grWindowed ? 0 : SDL_WINDOW_FULLSCREEN)
     );
+#ifdef __EMSCRIPTEN__
+    emscripten_set_canvas_element_size("#canvas", 640, 480);
+#endif
 
     if (sdl_window == NULL)
         fatalError("Could not create window: %s", SDL_GetError());

--- a/sound.c
+++ b/sound.c
@@ -22,6 +22,10 @@
  */
 
 #include <SDL2/SDL.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+EM_JS_DEPS(sdlaudio, "$autoResumeAudioContext,$dynCall")
+#endif
 #include <string.h>
 
 #include "mytypes.h"

--- a/story.c
+++ b/story.c
@@ -23,6 +23,9 @@
 
 #include <stdlib.h>
 #include <string.h>
+#ifdef __EMSCRIPTEN__
+#include <emscripten.h>
+#endif
 
 #include "mytypes.h"
 #include "utils.h"
@@ -191,89 +194,102 @@ static void storyCalculateIslandFromScene(struct TStoryScene *scene)
 }
 
 
+struct MainLoopData {
+    uint16 wantedFlags;
+    uint16 unwantedFlags;
+};
+
+void mainLoop(void *voidData)
+{
+    struct MainLoopData *data = (struct MainLoopData *)voidData;
+    storyUpdateCurrentDay();
+    storyCalculateIslandFromDateAndTime();
+    data->unwantedFlags = 0;
+
+    struct TStoryScene *finalScene = storyPickScene(FINAL, data->unwantedFlags);
+
+    if (finalScene->flags & ISLAND) {
+        storyCalculateIslandFromScene(finalScene);
+        adsInitIsland();
+    }
+    else {
+        adsNoIsland();
+    }
+
+    int prevSpot = -1;
+    int prevHdg  = -1;
+
+    if (!(finalScene->flags & FIRST)) {
+
+        data->wantedFlags = 0;
+        data->unwantedFlags |= FINAL;
+
+        if (islandState.lowTide)
+            data->wantedFlags |= LOWTIDE_OK;
+
+        if (islandState.xPos || islandState.yPos)
+            data->wantedFlags |= VARPOS_OK;
+
+        for (int i=0; i < 6 + (rand() % 14); i++) {
+
+            struct TStoryScene *scene = storyPickScene(data->wantedFlags,
+                                                        data->unwantedFlags);
+
+            if (prevSpot != -1)
+                adsPlayWalk(prevSpot, prevHdg,
+                    scene->spotStart, scene->hdgStart);
+
+            ttmDx = islandState.xPos
+                        + (scene->flags & LEFT_ISLAND ? 272 : 0);
+            ttmDy = islandState.yPos;
+
+            if (scene->dayNo)
+                soundPlay(0);
+
+            adsPlay(scene->adsName, scene->adsTagNo);
+
+            data->unwantedFlags |= FIRST;
+            prevSpot = scene->spotEnd;
+            prevHdg = scene->hdgEnd;
+        }
+    }
+
+    if (prevSpot != -1)
+        adsPlayWalk(prevSpot, prevHdg, finalScene->spotStart, finalScene->hdgStart);
+
+    if (finalScene->flags & ISLAND) {
+        ttmDx = islandState.xPos + (finalScene->flags & LEFT_ISLAND ? 272 : 0);
+        ttmDy = islandState.yPos;
+    }
+    else {
+        ttmDx = ttmDy = 0;
+    }
+
+    if (finalScene->dayNo)
+        soundPlay(0);
+
+    adsPlay(finalScene->adsName, finalScene->adsTagNo);
+
+    grFadeOut();
+
+    if (finalScene->flags & ISLAND)
+        adsReleaseIsland();
+}
+
+
 void storyPlay()
 {
-    uint16 wantedFlags   = 0;
-    uint16 unwantedFlags = 0;
-
+    struct MainLoopData data = { 0 };
 
     adsInit();
     adsPlayIntro();
 
+#ifdef __EMSCRIPTEN__
+    emscripten_set_main_loop_arg(mainLoop, &data, 0, 1);
+#else
     while (1) {
-
-        storyUpdateCurrentDay();
-        storyCalculateIslandFromDateAndTime();
-        unwantedFlags = 0;
-
-        struct TStoryScene *finalScene = storyPickScene(FINAL, unwantedFlags);
-
-        if (finalScene->flags & ISLAND) {
-            storyCalculateIslandFromScene(finalScene);
-            adsInitIsland();
-        }
-        else {
-            adsNoIsland();
-        }
-
-        int prevSpot = -1;
-        int prevHdg  = -1;
-
-        if (!(finalScene->flags & FIRST)) {
-
-            wantedFlags = 0;
-            unwantedFlags |= FINAL;
-
-            if (islandState.lowTide)
-                wantedFlags |= LOWTIDE_OK;
-
-            if (islandState.xPos || islandState.yPos)
-                wantedFlags |= VARPOS_OK;
-
-            for (int i=0; i < 6 + (rand() % 14); i++) {
-
-                struct TStoryScene *scene = storyPickScene(wantedFlags,
-                                                           unwantedFlags);
-
-                if (prevSpot != -1)
-                    adsPlayWalk(prevSpot, prevHdg,
-                        scene->spotStart, scene->hdgStart);
-
-                ttmDx = islandState.xPos
-                            + (scene->flags & LEFT_ISLAND ? 272 : 0);
-                ttmDy = islandState.yPos;
-
-                if (scene->dayNo)
-                    soundPlay(0);
-
-                adsPlay(scene->adsName, scene->adsTagNo);
-
-                unwantedFlags |= FIRST;
-                prevSpot = scene->spotEnd;
-                prevHdg = scene->hdgEnd;
-            }
-        }
-
-        if (prevSpot != -1)
-            adsPlayWalk(prevSpot, prevHdg, finalScene->spotStart, finalScene->hdgStart);
-
-        if (finalScene->flags & ISLAND) {
-            ttmDx = islandState.xPos + (finalScene->flags & LEFT_ISLAND ? 272 : 0);
-            ttmDy = islandState.yPos;
-        }
-        else {
-            ttmDx = ttmDy = 0;
-        }
-
-        if (finalScene->dayNo)
-            soundPlay(0);
-
-        adsPlay(finalScene->adsName, finalScene->adsTagNo);
-
-        grFadeOut();
-
-        if (finalScene->flags & ISLAND)
-            adsReleaseIsland();
+        mainLoop(&data);
     }
+#endif
 }
 


### PR DESCRIPTION
I updated this to run in the browser using Emscripten. It runs well on Chrome and Firefox for me
<img width="1068" alt="jc_reborn_firefox" src="https://github.com/jno6809/jc_reborn/assets/6298931/f157dde4-8ab7-481b-8290-5d7f09477580">

It still builds under MacOS X using the Linux Makefile (`make -f Makefile.linux`), but now it also builds with Emscripten (`emmake make -f Makefile.linux`).

Since the code uses blocking calls to `SDL_Delay` I built with Asyncify, and only a few minor changes were required. 
 * Calls to `SDL_Delay` were changed to `emscripten_sleep` to avoid blocking the main thread. 
 * Calls to `exit` were changed to `emscripten_force_exit` to avoid exceptions being thrown after exiting
 * A hint function is called to keep Emscripten from resizing the canvas element. 
 
All emscripten-specific changes, including in the Makefile, are made with a preprocessor switch (`#ifdef __EMSCRIPTEN__`), so the old functionality isn't affected.

UPDATE: Removed main loop refactor after realizing it wasn't necessary when using Asyncify